### PR TITLE
Fixes https links

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
   <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" href="tagoverflow.css">
   <meta property='og:title' content="TagOverflow">
-  <meta property='og:url' content="http://stared.github.io/tagoverflow/">
+  <meta property='og:url' content="https://stared.github.io/tagoverflow/">
   <meta property='og:description' content="TagOverflow - interactive visualization of tags from StackExchange sites (e.g. StackOverflow, MathOverflow, ...).">
-  <meta property='og:image' content="http://stared.github.io/tagoverflow/screenshot_dev.png">
+  <meta property='og:image' content="https://stared.github.io/tagoverflow/screenshot_dev.png">
 </head>
 
 <body>
@@ -99,7 +99,7 @@
     </div>
   </div>
 </div>
-<script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 <script src="d3.v3.min.js"></script>
 <script src="se_query.js"></script>
 <script src="se_tags.js"></script>


### PR DESCRIPTION
GitHub Pages is now HTTPS by default, thus blocking jQuery
